### PR TITLE
dsp decay times multiple dispatch

### DIFF
--- a/src/dsp_decaytime.jl
+++ b/src/dsp_decaytime.jl
@@ -1,31 +1,26 @@
 # This file is a part of LegendDSP.jl, licensed under the MIT License (MIT).
 
 """
-    dsp_decay_times(wvfs::AbstractSamples, start::Real, stop::Real)
-
-Get statistics on the logarhithmic of the tail of the `wvfs` in the interval (`start`,`stop`).
+    dsp_decay_times(wvfs::ArrayOfRDWaveforms, bl_window::ClosedInterval{<:Unitful.Time{<:T}}, tail_window::ClosedInterval{<:Unitful.Time{<:T}})
+    dsp_decay_times(wvfs::ArrayOfRDWaveforms, config::DSPConfig)
+    
+Get statistics on the logarhithmic of the tail of the `wvfs` in the interval `tail_window`.
 # Returns
 - `τ`: decay time in µs
 """
-function dsp_decay_times(wvfs::ArrayOfRDWaveforms, bl_mean::Tuple, pz_fit::Tuple)
-    # get config parameters
-    bl_mean_min, bl_mean_max    = bl_mean
-    pz_fit_min, pz_fit_max      = pz_fit
-
+function dsp_decay_times(wvfs::ArrayOfRDWaveforms, bl_window::ClosedInterval{<:Unitful.Time{<:T}}, tail_window::ClosedInterval{<:Unitful.Time{<:T}}) where T <: Real
     # get baseline mean, std and slope
-    bl_stats = signalstats.(wvfs, bl_mean_min, bl_mean_max)
+    bl_stats = signalstats.(wvfs, first(bl_window), last(bl_window))
 
     # substract baseline from waveforms
     wvfs_bl = shift_waveform.(wvfs, -bl_stats.mean)
 
     # extract decay times
-    decay_times = tailstats.(wvfs_bl, pz_fit_min, pz_fit_max)
+    decay_times = tailstats.(wvfs_bl, first(tail_window), last(tail_window))
     
     # return converted to µs vals
     return uconvert.(u"µs", decay_times.τ)
 end
-
-function dsp_decay_times(wvfs::ArrayOfRDWaveforms, config::DSPConfig)
-    dsp_decay_times(wvfs, config.bl_mean, config.pz_fit)
-end
 export dsp_decay_times
+
+dsp_decay_times(wvfs::ArrayOfRDWaveforms, config::DSPConfig) = dsp_decay_times(wvfs, config.bl_window, config.tail_window)

--- a/src/dsp_decaytime.jl
+++ b/src/dsp_decaytime.jl
@@ -1,25 +1,31 @@
 # This file is a part of LegendDSP.jl, licensed under the MIT License (MIT).
 
 """
-    dsp_decay_times(wvfs::AbstractSamples, config::DSPConfig)
+    dsp_decay_times(wvfs::AbstractSamples, start::Real, stop::Real)
 
-Get statistics on the logarhithmic of the tail of the `wvfs` in the interval `tail_window`.
+Get statistics on the logarhithmic of the tail of the `wvfs` in the interval (`start`,`stop`).
 # Returns
 - `τ`: decay time in µs
 """
-function dsp_decay_times(wvfs::ArrayOfRDWaveforms, bl_window::ClosedInterval{<:Quantity{<:T}}, tail_window::ClosedInterval{<:Quantity{<:T}}) where T <: Real
+function dsp_decay_times(wvfs::ArrayOfRDWaveforms, bl_mean::Tuple, pz_fit::Tuple)
+    # get config parameters
+    bl_mean_min, bl_mean_max    = bl_mean
+    pz_fit_min, pz_fit_max      = pz_fit
+
     # get baseline mean, std and slope
-    bl_stats = signalstats.(wvfs, first(bl_window), last(bl_window))
+    bl_stats = signalstats.(wvfs, bl_mean_min, bl_mean_max)
 
     # substract baseline from waveforms
     wvfs_bl = shift_waveform.(wvfs, -bl_stats.mean)
 
     # extract decay times
-    decay_times = tailstats.(wvfs_bl, first(tail_window), last(tail_window))
+    decay_times = tailstats.(wvfs_bl, pz_fit_min, pz_fit_max)
     
     # return converted to µs vals
     return uconvert.(u"µs", decay_times.τ)
 end
-export dsp_decay_times
 
-dsp_decay_times(wvfs::ArrayOfRDWaveforms, config::DSPConfig) = dsp_decay_times(wvfs, config.bl_window, config.tail_window)
+function dsp_decay_times(wvfs::ArrayOfRDWaveforms, config::DSPConfig)
+    dsp_decay_times(wvfs, config.bl_mean, config.pz_fit)
+end
+export dsp_decay_times

--- a/src/dsp_decaytime.jl
+++ b/src/dsp_decaytime.jl
@@ -7,11 +7,7 @@ Get statistics on the logarhithmic of the tail of the `wvfs` in the interval `ta
 # Returns
 - `τ`: decay time in µs
 """
-function dsp_decay_times(wvfs::ArrayOfRDWaveforms, config::DSPConfig)
-    # get config parameters
-    bl_window    = config.bl_window
-    tail_window  = config.tail_window
-
+function dsp_decay_times(wvfs::ArrayOfRDWaveforms, bl_window::ClosedInterval{<:Quantity{<:T}}, tail_window::ClosedInterval{<:Quantity{<:T}}) where T <: Real
     # get baseline mean, std and slope
     bl_stats = signalstats.(wvfs, first(bl_window), last(bl_window))
 
@@ -25,3 +21,5 @@ function dsp_decay_times(wvfs::ArrayOfRDWaveforms, config::DSPConfig)
     return uconvert.(u"µs", decay_times.τ)
 end
 export dsp_decay_times
+
+dsp_decay_times(wvfs::ArrayOfRDWaveforms, config::DSPConfig) = dsp_decay_times(wvfs, config.bl_window, config.tail_window)

--- a/src/dsp_decaytime.jl
+++ b/src/dsp_decaytime.jl
@@ -1,25 +1,25 @@
 # This file is a part of LegendDSP.jl, licensed under the MIT License (MIT).
 
 """
-    dsp_decay_times(wvfs::AbstractSamples, start::Real, stop::Real)
+    dsp_decay_times(wvfs::AbstractSamples, config::DSPConfig)
 
-Get statistics on the logarhithmic of the tail of the `wvfs` in the interval (`start`,`stop`).
+Get statistics on the logarhithmic of the tail of the `wvfs` in the interval `tail_window`.
 # Returns
 - `τ`: decay time in µs
 """
 function dsp_decay_times(wvfs::ArrayOfRDWaveforms, config::DSPConfig)
     # get config parameters
-    bl_mean_min, bl_mean_max    = config.bl_mean
-    pz_fit_min, pz_fit_max      = config.pz_fit
+    bl_window    = config.bl_window
+    tail_window  = config.tail_window
 
     # get baseline mean, std and slope
-    bl_stats = signalstats.(wvfs, bl_mean_min, bl_mean_max)
+    bl_stats = signalstats.(wvfs, first(bl_window), last(bl_window))
 
     # substract baseline from waveforms
     wvfs_bl = shift_waveform.(wvfs, -bl_stats.mean)
 
     # extract decay times
-    decay_times = tailstats.(wvfs_bl, pz_fit_min, pz_fit_max)
+    decay_times = tailstats.(wvfs_bl, first(tail_window), last(tail_window))
     
     # return converted to µs vals
     return uconvert.(u"µs", decay_times.τ)

--- a/src/dsp_filter_optimization.jl
+++ b/src/dsp_filter_optimization.jl
@@ -10,12 +10,12 @@ Get ENC noise grid values for given trap grid rise times.
 """
 function dsp_trap_rt_optimization(wvfs::ArrayOfRDWaveforms, config::DSPConfig, τ::Quantity{T},; ft::Quantity{T}=4.0u"µs") where T<:Real
     # get config parameters
-    bl_mean_min, bl_mean_max    = config.bl_mean
+    bl_window                   = config.bl_window
     e_grid_rt_trap              = config.e_grid_rt_trap
     enc_pickoff_trap            = config.enc_pickoff_trap
 
     # get baseline mean, std and slope
-    bl_stats = signalstats.(wvfs, bl_mean_min, bl_mean_max)
+    bl_stats = signalstats.(wvfs, first(bl_window), last(bl_window))
 
     # substract baseline from waveforms
     wvfs = shift_waveform.(wvfs, -bl_stats.mean)
@@ -54,7 +54,7 @@ Get ENC noise grid values for given CUSP grid rise times.
 """
 function dsp_cusp_rt_optimization(wvfs::ArrayOfRDWaveforms, config::DSPConfig, τ::Quantity{T},; ft::Quantity{T}=4.0u"µs") where T<:Real
     # get config parameters
-    bl_mean_min, bl_mean_max    = config.bl_mean
+    bl_window                   = config.bl_window
     e_grid_rt_cusp              = config.e_grid_rt_cusp
     enc_pickoff_cusp            = config.enc_pickoff_cusp
     flt_length_cusp             = config.flt_length_cusp
@@ -64,7 +64,7 @@ function dsp_cusp_rt_optimization(wvfs::ArrayOfRDWaveforms, config::DSPConfig, �
     τ_cusp = 10000000.0u"µs"
 
     # get baseline mean, std and slope
-    bl_stats = signalstats.(wvfs, bl_mean_min, bl_mean_max)
+    bl_stats = signalstats.(wvfs, first(bl_window), last(bl_window))
 
     # substract baseline from waveforms
     wvfs = shift_waveform.(wvfs, -bl_stats.mean)
@@ -107,7 +107,7 @@ Get ENC noise grid values for given ZAC grid rise times.
 """
 function dsp_zac_rt_optimization(wvfs::ArrayOfRDWaveforms, config::DSPConfig, τ::Quantity{T},; ft::Quantity{T}=4.0u"µs") where T<:Real
     # get config parameters
-    bl_mean_min, bl_mean_max    = config.bl_mean
+    bl_window                   = config.bl_window
     e_grid_rt_zac               = config.e_grid_rt_zac
     enc_pickoff_zac             = config.enc_pickoff_zac
     flt_length_zac              = config.flt_length_zac
@@ -117,7 +117,7 @@ function dsp_zac_rt_optimization(wvfs::ArrayOfRDWaveforms, config::DSPConfig, τ
     τ_zac = 10000000.0u"µs"
 
     # get baseline mean, std and slope
-    bl_stats = signalstats.(wvfs, bl_mean_min, bl_mean_max)
+    bl_stats = signalstats.(wvfs, first(bl_window), last(bl_window))
 
     # substract baseline from waveforms
     wvfs = shift_waveform.(wvfs, -bl_stats.mean)
@@ -160,11 +160,11 @@ Get energy grid values for given trap grid rise times while varying the flat-top
 """
 function dsp_trap_ft_optimization(wvfs::ArrayOfRDWaveforms, config::DSPConfig, τ::Quantity{T}, rt::Quantity{T}) where T<:Real
     # get config parameters
-    bl_mean_min, bl_mean_max    = config.bl_mean
+    bl_window                   = config.bl_window
     e_grid_ft_trap              = config.e_grid_ft_trap
 
     # get baseline mean, std and slope
-    bl_stats = signalstats.(wvfs, bl_mean_min, bl_mean_max)
+    bl_stats = signalstats.(wvfs, first(bl_window), last(bl_window))
 
     # substract baseline from waveforms
     wvfs = shift_waveform.(wvfs, -bl_stats.mean)
@@ -207,7 +207,7 @@ Get energy grid values for given CUSP grid rise times while varying the flat-top
 """
 function dsp_cusp_ft_optimization(wvfs::ArrayOfRDWaveforms, config::DSPConfig, τ::Quantity{T}, rt::Quantity{T}) where T<:Real
     # get config parameters
-    bl_mean_min, bl_mean_max    = config.bl_mean
+    bl_window                   = config.bl_window
     e_grid_ft_cusp              = config.e_grid_ft_cusp
     flt_length_cusp             = config.flt_length_cusp
     cusp_scale                  = ustrip(NoUnits, flt_length_cusp/step(wvfs[1].time))
@@ -216,7 +216,7 @@ function dsp_cusp_ft_optimization(wvfs::ArrayOfRDWaveforms, config::DSPConfig, �
     τ_cusp = 10000000.0u"µs"
 
     # get baseline mean, std and slope
-    bl_stats = signalstats.(wvfs, bl_mean_min, bl_mean_max)
+    bl_stats = signalstats.(wvfs, first(bl_window), last(bl_window))
 
     # substract baseline from waveforms
     wvfs = shift_waveform.(wvfs, -bl_stats.mean)
@@ -259,7 +259,7 @@ Returns:
 """
 function dsp_zac_ft_optimization(wvfs::ArrayOfRDWaveforms, config::DSPConfig, τ::Quantity{T}, rt::Quantity{T}) where T<:Real
     # get config parameters
-    bl_mean_min, bl_mean_max    = config.bl_mean
+    bl_window                   = config.bl_window
     e_grid_ft_zac               = config.e_grid_ft_zac
     flt_length_zac              = config.flt_length_zac
     zac_scale                   = ustrip(NoUnits, flt_length_zac/step(wvfs[1].time))
@@ -268,7 +268,7 @@ function dsp_zac_ft_optimization(wvfs::ArrayOfRDWaveforms, config::DSPConfig, τ
     τ_zac = 10000000.0u"µs"
 
     # get baseline mean, std and slope
-    bl_stats = signalstats.(wvfs, bl_mean_min, bl_mean_max)
+    bl_stats = signalstats.(wvfs, first(bl_window), last(bl_window))
 
     # substract baseline from waveforms
     wvfs = shift_waveform.(wvfs, -bl_stats.mean)
@@ -314,7 +314,7 @@ Optimize the Savitzky-Golay filter parameters for a given waveform set.
 """
 function dsp_sg_optimization(wvfs::ArrayOfRDWaveforms, config::DSPConfig, τ::Quantity{T}, pars_filter::PropDict) where T<:Real
     # get config parameters
-    bl_mean_min, bl_mean_max    = config.bl_mean
+    bl_window                   = config.bl_window
     a_grid_wl_sg                = config.a_grid_wl_sg
 
     # get optimal filter parameters
@@ -322,7 +322,7 @@ function dsp_sg_optimization(wvfs::ArrayOfRDWaveforms, config::DSPConfig, τ::Qu
     ft = pars_filter.trap.ft.val*u"µs"
 
     # get baseline mean, std and slope
-    bl_stats = signalstats.(wvfs, bl_mean_min, bl_mean_max)
+    bl_stats = signalstats.(wvfs, first(bl_window), last(bl_window))
 
     # substract baseline from waveforms
     wvfs = shift_waveform.(wvfs, -bl_stats.mean)

--- a/src/dsp_icpc.jl
+++ b/src/dsp_icpc.jl
@@ -24,9 +24,12 @@ The output data is a table with the following columns:
 - `tailslope`: tail slope after PZ correction
 - `tailoffset`: tail offset after PZ correction
 - `t0`: start time of waveform drift
+- `t10`: timepoint of 10% of waveform maximum
 - `t50`: timepoint of 50% of waveform maximum
 - `t80`: timepoint of 80% of waveform maximum
-- `t0_current`: timepoint of current rise start
+- `t90`: timepoint of 90% of waveform maximum
+- `t99`: timepoint of 99% of waveform maximum
+- `t50_current`: timepoint of current rise to 50% of maximum
 - `tail_τ`: tail decay time
 - `tail_mean`: tail mean before PZ correction
 - `tail_sigma`: tail sigma before PZ correction
@@ -48,9 +51,6 @@ The output data is a table with the following columns:
 - `eventID_fadc`: event ID from FADC
 - `e_fc`: energy from FADC
 - `pretrace_diff`: difference between first sample and baseline mean
-- `rt1090`: rise time between 10% and 90% of waveform maximum
-- `rt1099`: rise time between 10% and 99% of waveform maximum
-- `rt9099`: rise time between 90% and 99% of waveform maximum
 - `drift_time`: drift time between t0 and 90% of waveform maximum
 - `inTrace_intersect`: position of in-trace pile-up
 - `inTrace_n`: multiplicity of in-trace pile-up
@@ -106,126 +106,100 @@ function dsp_icpc(data::Q, config::DSPConfig, τ::Quantity{T}, pars_filter::Prop
     # substract baseline from waveforms
     wvfs = shift_waveform.(wvfs, -bl_stats.mean)
 
-    # extract decay times
-    tail_stats = tailstats.(wvfs, pz_fit_min, pz_fit_max)
-
-    # deconvolute waveform
-    deconv_flt = InvCRFilter(τ)
-    wvfs_pz = deconv_flt.(wvfs)
-
-    # get tail mean, std and slope
-    pz_stats = signalstats.(wvfs_pz, pz_fit_min, pz_fit_max)
-
     # get wvf maximum
     wvf_max = maximum.(wvfs.signal)
     wvf_min = minimum.(wvfs.signal)
 
+    # extract decay times
+    tail_stats = tailstats.(wvfs, pz_fit_min, pz_fit_max)
+
+    # deconvolute waveform 
+    # --> wvfs = wvfs_pz
+    deconv_flt = InvCRFilter(τ)
+    wvfs = deconv_flt.(wvfs)
+
+    # get tail mean, std and slope
+    pz_stats = signalstats.(wvfs, pz_fit_min, pz_fit_max)
+
     # t0 determination
-    t0 = get_t0(wvfs_pz, t0_threshold)
+    t0 = get_t0(wvfs, t0_threshold)
 
-    # t50 determination
-    t50 = get_t50(wvfs_pz, wvf_max)
-
-    # t80 determination
-    t80 = get_t80(wvfs_pz, wvf_max)
-
-    # sanity --> replace NaNs to have consistency with the other code
-    replace!(t0, NaN*unit(t0[1]) => zero(t0[1]))
-    replace!(t50, NaN*unit(t50[1]) => zero(t50[1]))
-    replace!(t80, NaN*unit(t80[1]) => zero(t80[1]))
-
-    # get risetimes and drift times by intersection
-    flt_intersec_90RT = Intersect(mintot = 100u"ns")
-    flt_intersec_99RT = Intersect(mintot = 20u"ns")
-    flt_intersec_lowRT = Intersect(mintot = 600u"ns")
+    # get threshold points in rise
+    t10 = get_threshold(wvfs, wvf_max .* 0.1)
+    t50 = get_threshold(wvfs, wvf_max .* 0.5)
+    t80 = get_threshold(wvfs, wvf_max .* 0.8)
+    t90 = get_threshold(wvfs, wvf_max .* 0.9)
+    t99 = get_threshold(wvfs, wvf_max .* 0.99)
     
-    rt1090     = uconvert.(u"ns", flt_intersec_90RT.(wvfs_pz, wvf_max .* 0.9).x - flt_intersec_lowRT.(wvfs_pz, wvf_max .* 0.1).x)
-    rt1099     = uconvert.(u"ns", flt_intersec_99RT.(wvfs_pz, wvf_max .* 0.99).x - flt_intersec_lowRT.(wvfs_pz, wvf_max .* 0.1).x)
-    rt9099     = uconvert.(u"ns", flt_intersec_99RT.(wvfs_pz, wvf_max .* 0.99).x - flt_intersec_90RT.(wvfs_pz, wvf_max .* 0.90).x)
-    drift_time = uconvert.(u"ns", flt_intersec_90RT.(wvfs_pz, wvf_max .* 0.90).x - t0)
+    drift_time = uconvert.(u"ns", t90 - t0)
 
     # get Q-drift parameter
-    int_flt = IntegratorFilter(1)
-    wvfs_flt_int = int_flt.(wvfs_pz)
-
-    area1  = SignalEstimator(PolynomialDNI(3, 100u"ns")).(wvfs_flt_int, t0 .+ 2.5u"µs") .- SignalEstimator(PolynomialDNI(3, 100u"ns")).(wvfs_flt_int, t0)
-    area2  = SignalEstimator(PolynomialDNI(3, 100u"ns")).(wvfs_flt_int, t0 .+ 5u"µs")   .- SignalEstimator(PolynomialDNI(3, 100u"ns")).(wvfs_flt_int, t0 .+ 2.5u"µs")
-    qdrift = area2 .- area1
+    qdrift = get_qdrift(wvfs, t0, (2.5:5.0)u"µs")
 
     # get LQ parameter
-    area1 = SignalEstimator(PolynomialDNI(3, 100u"ns")).(wvfs_flt_int, t80 .+ 2.5u"µs") .- SignalEstimator(PolynomialDNI(3, 100u"ns")).(wvfs_flt_int, t80)
-    area2 = SignalEstimator(PolynomialDNI(3, 100u"ns")).(wvfs_flt_int, t80 .+ 5u"µs")   .- SignalEstimator(PolynomialDNI(3, 100u"ns")).(wvfs_flt_int, t80 .+ 2.5u"µs")
-    lq    = area2 .- area1
+    lq  = get_qdrift(wvfs, t80, (2.5:5.0)u"µs")
 
-    # extract energy and ENC noise param from maximum of filtered wvfs
+    # robust energy reconstruction with long, middle and short rise and flat-top times
     uflt_10410 = TrapezoidalChargeFilter(10u"µs", 4u"µs")
+    e_10410  = maximum.((uflt_10410.(wvfs)).signal)
 
-    wvfs_flt = uflt_10410.(wvfs_pz)
-    e_10410  = SignalEstimator(PolynomialDNI(3, 100u"ns")).(wvfs_flt, t50 .+ 12u"µs")
+    uflt_535 = TrapezoidalChargeFilter(5u"µs", 3u"µs")
+    e_535  = maximum.((uflt_535.(wvfs)).signal)
 
-    # extract energy and ENC noise param from maximum of filtered wvfs
     uflt_313 = TrapezoidalChargeFilter(3u"µs", 1u"µs")
+    e_313  = maximum.((uflt_313.(wvfs)).signal)
 
-    wvfs_flt = uflt_313.(wvfs_pz)
-    e_313  = SignalEstimator(PolynomialDNI(3, 100u"ns")).(wvfs_flt, t50 .+ 3.5u"µs")
+    # signal estimator for precise energy reconstruction
+    signal_estimator = SignalEstimator(PolynomialDNI(3, 100u"ns"))
 
     # get trap energy of optimized rise and flat-top time
     uflt_trap_rtft = TrapezoidalChargeFilter(trap_rt, trap_ft)
 
-    wvfs_flt = uflt_trap_rtft.(wvfs_pz)
-    e_trap   = SignalEstimator(PolynomialDNI(3, 100u"ns")).(wvfs_flt, t50 .+ (trap_rt + trap_ft/2))
+    e_trap = signal_estimator.(uflt_trap_rtft.(wvfs), t50 .+ (trap_rt + trap_ft/2))
 
     # get cusp energy of optimized rise and flat-top time
     uflt_cusp_rtft = CUSPChargeFilter(cusp_rt, cusp_ft, τ_cusp, flt_length_cusp, cusp_scale)
 
-    wvfs_flt = uflt_cusp_rtft.(wvfs_pz)
-    e_cusp   = SignalEstimator(PolynomialDNI(3, 100u"ns")).(wvfs_flt, t50 .+ (flt_length_cusp /2))
+    e_cusp = signal_estimator.(uflt_cusp_rtft.(wvfs), t50 .+ (flt_length_cusp /2))
 
     # get zac energy of optimized rise and flat-top time
     uflt_zac_rtft = ZACChargeFilter(zac_rt, zac_ft, τ_zac, flt_length_zac, zac_scale)
 
-    wvfs_flt = uflt_zac_rtft.(wvfs_pz)
-    e_zac    = SignalEstimator(PolynomialDNI(3, 100u"ns")).(wvfs_flt, t50 .+ (flt_length_zac /2))
+    e_zac = signal_estimator.(uflt_zac_rtft.(wvfs), t50 .+ (flt_length_zac /2))
 
-    # extract current with filter length of 180ns with second order polynominal and first derivative
-    sgflt_deriv = SavitzkyGolayFilter(sg_wl, 2, 1)
-    wvfs_sgflt_deriv = sgflt_deriv.(wvfs_pz)
-    current_max = get_wvf_maximum.(wvfs_sgflt_deriv, 20u"µs", 100u"µs")
+    # extract current with optimal SG filter length with second order polynominal and first derivative
+    wvfs_sgflt_deriv = SavitzkyGolayFilter(sg_wl, 2, 1).(wvfs)
 
-    # in-trace pile-up rejector
-    flt_intersec_inTrace = Intersect(mintot = 100u"ns")
-    deriv_stats = signalstats.(wvfs_sgflt_deriv, bl_mean_min + wvfs_sgflt_deriv.time[1][1], bl_mean_max)
-    # threshold over std
-    inTraceCut = inTraceCut_std_threshold .* deriv_stats.sigma
+    current_window = (20.0:100.0)u"µs"
+    current_max = get_wvf_maximum.(wvfs_sgflt_deriv, first(current_window), last(current_window))
 
-    # get position and multiplicity of in-trace pile-up
-    inTrace_pileUp      = flt_intersec_inTrace.(reverse_waveform.(wvfs_sgflt_deriv), inTraceCut)
-    inTrace_intersect   = wvfs_pz.time[1][end] .- inTrace_pileUp.x
-    inTrace_n           = inTrace_pileUp.multiplicity
-
-    # get position of current rise start
-    t0_current = LegendDSP.get_t50(wvfs_sgflt_deriv, maximum.(wvfs_sgflt_deriv.signal))
+    # get in-trace pile-up
+    inTrace_pileUp = get_intracePileUp(wvfs_sgflt_deriv, inTraceCut_std_threshold, bl_mean_min, bl_mean_max)
+    
+    # get position of current rise
+    t50_current = get_threshold(wvfs_sgflt_deriv, maximum.(wvfs_sgflt_deriv.signal) .* 0.5; mintot=300u"ns")
 
     # invert waveform for DC tagging
-    wvfs_pz_inv = multiply_waveform.(wvfs_pz, -1.0)
+    # wvfs --> wvfs_pz_inv
+    wvfs = multiply_waveform.(wvfs, -1.0)
 
-    # get inverted waveform maximum
-    wvfs_flt = uflt_10410.(wvfs_pz_inv)
-    e_10410_max_inv  = maximum.(wvfs_flt.signal)
+    # get inverted waveform maximum for long and short filter
+    e_10410_max_inv  = maximum.(uflt_10410.(wvfs).signal)
 
-    wvfs_flt = uflt_313.(wvfs_pz_inv)
-    e_313_max_inv  = maximum.(wvfs_flt.signal)
+    e_313_max_inv  = maximum.(uflt_313.(wvfs).signal)
 
     # t0 determination
-    t0_inv = get_t0(wvfs_pz_inv, t0_threshold)
+    t0_inv = get_t0(wvfs, t0_threshold)
 
     # output Table 
     return TypedTables.Table(blmean = bl_stats.mean, blsigma = bl_stats.sigma, blslope = bl_stats.slope, bloffset = bl_stats.offset, 
     tailmean = pz_stats.mean, tailsigma = pz_stats.sigma, tailslope = pz_stats.slope, tailoffset = pz_stats.offset,
-    t0 = t0, t50 = t50, t80 = t80, t0_current = t0_current,
+    t0 = t0, t10 = t10, t50 = t50, t80 = t80, t90 = t90, t99 = t99,
+    t50_current = t50_current, 
+    drift_time = drift_time,
     tail_τ = tail_stats.τ, tail_mean = tail_stats.mean, tail_sigma = tail_stats.sigma,
     e_max = wvf_max, e_min = wvf_min,
-    e_10410 = e_10410, e_313 = e_313,
+    e_10410 = e_10410, e_535 = e_535, e_313 = e_313,
     e_10410_inv = e_10410_max_inv, e_313_inv = e_313_max_inv,
     t0_inv = t0_inv,
     e_trap = e_trap, e_cusp = e_cusp, e_zac = e_zac, 
@@ -233,8 +207,7 @@ function dsp_icpc(data::Q, config::DSPConfig, τ::Quantity{T}, pars_filter::Prop
     a = current_max,
     blfc = blfc, timestamp = ts, eventID_fadc = evID, e_fc = efc,
     pretrace_diff = pretrace_diff, 
-    rt1090 = rt1090, rt1099 = rt1099, rt9099 = rt9099, drift_time = drift_time,
-    inTrace_intersect = inTrace_intersect, inTrace_n = inTrace_n,
+    inTrace_intersect = inTrace_pileUp.intersect, inTrace_n = inTrace_pileUp.n,
     n_sat_low = sat_stats.low, n_sat_high = sat_stats.high, n_sat_low_cons = sat_stats.max_cons_low, n_sat_high_cons = sat_stats.max_cons_high
     )
 end

--- a/src/dsp_icpc.jl
+++ b/src/dsp_icpc.jl
@@ -61,9 +61,9 @@ The output data is a table with the following columns:
 """
 function dsp_icpc(data::Q, config::DSPConfig, τ::Quantity{T}, pars_filter::PropDict) where {Q <: Table, T<:Real}
     # get config parameters
-    bl_mean_min, bl_mean_max    = config.bl_mean
+    bl_window                   = config.bl_window
     t0_threshold                = config.t0_threshold
-    pz_fit_min, pz_fit_max      = config.pz_fit
+    tail_window                 = config.tail_window
     inTraceCut_std_threshold    = config.inTraceCut_std_threshold
     
     # get optimal filter parameters
@@ -98,7 +98,7 @@ function dsp_icpc(data::Q, config::DSPConfig, τ::Quantity{T}, pars_filter::Prop
     τ_zac = 10000000.0u"µs"
 
     # get baseline mean, std and slope
-    bl_stats = signalstats.(wvfs, bl_mean_min, bl_mean_max)
+    bl_stats = signalstats.(wvfs, first(bl_window), last(bl_window))
 
     # pretrace difference 
     pretrace_diff = flatview(wvfs.signal)[1, :] - bl_stats.mean
@@ -111,7 +111,7 @@ function dsp_icpc(data::Q, config::DSPConfig, τ::Quantity{T}, pars_filter::Prop
     wvf_min = minimum.(wvfs.signal)
 
     # extract decay times
-    tail_stats = tailstats.(wvfs, pz_fit_min, pz_fit_max)
+    tail_stats = tailstats.(wvfs, first(tail_window), last(tail_window))
 
     # deconvolute waveform 
     # --> wvfs = wvfs_pz
@@ -174,7 +174,7 @@ function dsp_icpc(data::Q, config::DSPConfig, τ::Quantity{T}, pars_filter::Prop
     current_max = get_wvf_maximum.(wvfs_sgflt_deriv, first(current_window), last(current_window))
 
     # get in-trace pile-up
-    inTrace_pileUp = get_intracePileUp(wvfs_sgflt_deriv, inTraceCut_std_threshold, bl_mean_min, bl_mean_max)
+    inTrace_pileUp = get_intracePileUp(wvfs_sgflt_deriv, inTraceCut_std_threshold, bl_window)
     
     # get position of current rise
     t50_current = get_threshold(wvfs_sgflt_deriv, maximum.(wvfs_sgflt_deriv.signal) .* 0.5; mintot=300u"ns")

--- a/src/dsp_puls.jl
+++ b/src/dsp_puls.jl
@@ -28,7 +28,7 @@ The output data is a table with the following columns:
 """
 function dsp_puls(data::Q, config::DSPConfig) where {Q <: Table}
     # get config parameters
-    bl_mean_min, bl_mean_max = config.bl_mean
+    bl_window = config.bl_window
 
     # get waveform data 
     wvfs = data.waveform
@@ -38,7 +38,7 @@ function dsp_puls(data::Q, config::DSPConfig) where {Q <: Table}
     efc  = data.daqenergy
 
     # get baseline mean, std and slope
-    bl_stats = signalstats.(wvfs, bl_mean_min, bl_mean_max)
+    bl_stats = signalstats.(wvfs, first(bl_window), last(bl_window))
 
     # substract baseline from waveforms
     wvfs = shift_waveform.(wvfs, -bl_stats.mean)

--- a/src/dsp_routines.jl
+++ b/src/dsp_routines.jl
@@ -70,10 +70,10 @@ export get_qdrift
 
 Get position and multiplicity of in-trace pile-up as intersect of reversed derivative signal with threshold as multiple of std. The `wvfs` have to be a current signal.
 """
-function get_intracePileUp(wvfs::ArrayOfRDWaveforms, sigma_threshold::Real, blmin::Unitful.Time{<:Real}, blmax::Unitful.Time{<:Real}; mintot::Unitful.Time=100.0u"ns")
+function get_intracePileUp(wvfs::ArrayOfRDWaveforms, sigma_threshold::Real, bl_window::ClosedInterval{Unitful.Time{<:Real}}; mintot::Unitful.Time=100.0u"ns")
     # get position and multiplicity of in-trace pile-up as intersect of reversed derivative signal with threshold as multiple of std
     flt_intersec_inTrace = Intersect(mintot = mintot)
-    inTrace_pileUp       = flt_intersec_inTrace.(reverse_waveform.(wvfs), signalstats.(wvfs, blmin + first(wvfs[1].time), blmax).sigma .* sigma_threshold)
+    inTrace_pileUp       = flt_intersec_inTrace.(reverse_waveform.(wvfs), signalstats.(wvfs, first(bl_window) + first(wvfs[1].time), last(bl_window)).sigma .* sigma_threshold)
     # return intersect position measured from the non-reversed waveform and multiplicity
     (intersect = last(wvfs[1].time) .- inTrace_pileUp.x, n = inTrace_pileUp.multiplicity)
 end

--- a/src/dsp_routines.jl
+++ b/src/dsp_routines.jl
@@ -19,31 +19,62 @@ function get_t0(wvfs_pz::ArrayOfRDWaveforms, t0_threshold::T) where T<:Real
     flt_intersec_t0 = Intersect(mintot = 1500u"ns")
 
     # get t0 for every waveform as pick-off at fixed threshold
-    uconvert.(u"µs", flt_intersec_t0.(wvfs_flt_asy_t0, t0_threshold).x)
+    t0 = uconvert.(u"µs", flt_intersec_t0.(wvfs_flt_asy_t0, t0_threshold).x)
+
+    # replace NaN to avoid problems with further processing
+    replace!(t0, NaN*unit(t0[1]) => zero(t0[1]))
 end
+export get_t0
 
 """
-    get_t50(wvfs_pz::ArrayOfRDWaveforms, wvf_max::T) where T<:Real
+    get_threshold(wvfs::ArrayOfRDWaveforms, threshold::Array{T}) where T<:Real
 
-Get t50 for each waveform in `wvfs_pz` by intersecting the waveform with a fixed threshold at `wvf_max * 0.5`.
+Get threshold for each waveform in `wvfs` by intersecting the waveform with a `threshold` per waveform or globally.
 """
-function get_t50(wvfs_pz::ArrayOfRDWaveforms, wvf_max::Array{T}) where T<:Real
+function get_threshold(wvfs::ArrayOfRDWaveforms, threshold::Union{Array{T}, T}; mintot::Unitful.Time=1000.0u"ns") where T<:Real
     # create intersect filter
-    flt_intersect = Intersect(mintot = 1000u"ns")
+    flt_intersect = Intersect(mintot = mintot)
 
-    # get t50 for every waveform as pick-off at fixed threshold
-    uconvert.(u"µs", flt_intersect.(wvfs_pz, wvf_max .* 0.5).x)
+    # get t0_threshold for every waveform as pick-off at fixed threshold
+    t_thres = uconvert.(u"µs", flt_intersect.(wvfs, threshold).x)
+
+    # replace NaN to avoid problems with further processing
+    replace!(t_thres, NaN*unit(t_thres[1]) => zero(t_thres[1]))
 end
+export get_threshold
+
 
 """
-    get_t80(wvfs_pz::ArrayOfRDWaveforms, wvf_max::T) where T<:Real
+    get_qdrift(wvfs::ArrayOfRDWaveforms, t_start::Array{Unitful.Time{T}}, Δt::UnitRange{Unitful.Time{T}}; pol_power::Int=3, sign_est_length::Unitful.Time=100u"ns")
 
-Get t80 for each waveform in `wvfs_pz` by intersecting the waveform with a fixed threshold at `wvf_max * 0.8`.
+Get the Q-drift parameter for each waveform in `wvfs` by integrating the waveform with gain = 1 and using a polynomial signal estimator of order `pol_power` and length `sign_est_length` to estimate the signal.
 """
-function get_t80(wvfs_pz::ArrayOfRDWaveforms, wvf_max::Array{T}) where T<:Real
-    # create intersect filter
-    flt_intersect = Intersect(mintot = 1000u"ns")
-
-    # get t50 for every waveform as pick-off at fixed threshold
-    uconvert.(u"µs", flt_intersect.(wvfs_pz, wvf_max .* 0.8).x)
+function get_qdrift(wvfs::ArrayOfRDWaveforms, t_start::Array{<:Unitful.Time{<:Real}}, Δt::StepRangeLen{<:Unitful.Time{<:Real}}; pol_power::Int=3, sign_est_length::Unitful.Time=100u"ns")
+    # Integrate waveforms with gain = 1
+    wvfs_flt_int = IntegratorFilter(1).(wvfs)
+    
+    # define signal estimator filter
+    signal_estimator = SignalEstimator(PolynomialDNI(pol_power, sign_est_length))
+    
+    # calculate area between t_start and t_start + Δt
+    area1  = signal_estimator.(wvfs_flt_int, t_start .+ first(Δt)) .- signal_estimator.(wvfs_flt_int, t_start)
+    area2  = signal_estimator.(wvfs_flt_int, t_start .+ last(Δt)) .- signal_estimator.(wvfs_flt_int, t_start .+ first(Δt))
+    
+    # return qdrift as differenc of areas
+    area2 .- area1
 end
+export get_qdrift
+
+"""
+    get_intracePileUp(wvfs::ArrayOfRDWaveforms, sigma_threshold::Real, blmin::Unitful.Time{<:Real}, blmax::Unitful.Time{<:Real}; mintot::Unitful.Time=100.0u"ns")
+
+Get position and multiplicity of in-trace pile-up as intersect of reversed derivative signal with threshold as multiple of std. The `wvfs` have to be a current signal.
+"""
+function get_intracePileUp(wvfs::ArrayOfRDWaveforms, sigma_threshold::Real, blmin::Unitful.Time{<:Real}, blmax::Unitful.Time{<:Real}; mintot::Unitful.Time=100.0u"ns")
+    # get position and multiplicity of in-trace pile-up as intersect of reversed derivative signal with threshold as multiple of std
+    flt_intersec_inTrace = Intersect(mintot = mintot)
+    inTrace_pileUp       = flt_intersec_inTrace.(reverse_waveform.(wvfs), signalstats.(wvfs, blmin + first(wvfs[1].time), blmax).sigma .* sigma_threshold)
+    # return intersect position measured from the non-reversed waveform and multiplicity
+    (intersect = last(wvfs[1].time) .- inTrace_pileUp.x, n = inTrace_pileUp.multiplicity)
+end
+export get_intracePileUp

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -18,7 +18,6 @@ Get the maximum of a `signal` in the interval (`start`,`stop`) by quadaratic int
 function get_wvf_maximum end
 export get_wvf_maximum
 
-
 function get_wvf_maximum(input::RadiationDetectorDSP.SamplesOrWaveform, start::RadiationDetectorDSP.RealQuantity, stop::RadiationDetectorDSP.RealQuantity)
     X_axis, Y = RadiationDetectorDSP._get_axis_and_signal(input)
     # ToDo: Lower numerical precision of x-axis to y-axis, if x-axis is a range

--- a/src/types.jl
+++ b/src/types.jl
@@ -11,8 +11,9 @@ Configuration parameters for DSP algorithms.
 
 # Fields
 - `enc_pickoff::Quantity{<:T}`: pick-off time for ENC noise calculations
-- `bl_mean::NTuple{2, Quantity{<:T}}`: fit window for basline extraction
-- `pz_fit::NTuple{2, Quantity{<:T}}`: fit window for decay time extraction
+- `bl_window::ClosedInterval{Quantity{<:T}}`: fit window for basline extraction
+- `tail_window::ClosedInterval{Quantity{<:T}}`: fit window for decay time extraction
+- `inTraceCut_std_threshold::T`: in-trace pile-up rejector threshold in standard deviations
 - `t0_threshold::T`: ADC threshold for t0 determination
 - `e_grid_rt_trap::StepRangeLen{Quantity{<:T}}`: rise time grid scan range for trapezoidal filter
 - `e_grid_ft_trap::StepRangeLen{Quantity{<:T}}`: flat-top time grid scan range for trapezoidal filter
@@ -20,20 +21,16 @@ Configuration parameters for DSP algorithms.
 - `e_grid_ft_zac::StepRangeLen{Quantity{<:T}}`: flat-top time grid scan range for ZAC filter
 - `e_grid_rt_cusp::StepRangeLen{Quantity{<:T}}`: rise time grid scan range for CUSP filter
 - `e_grid_ft_cusp::StepRangeLen{Quantity{<:T}}`: flat-top time grid scan range for CUSP filter
-- `e_grid_rt_sg::StepRangeLen{Quantity{<:T}}`: window length grid scan range for SG filter
+- `a_grid_rt_sg::StepRangeLen{Quantity{<:T}}`: window length grid scan range for SG filter
 
 # Examples
 ```julia
 using LegendDSP
-using Unitful
+using LegendDataManagement
 
-dsp_config = DSPConfig{Float64}(32.0u"µs", 
-(0.0u"µs", 39.0u"µs"), 
-(80.0u"µs", 110.0u"µs"), 
-5.0, 
-7.0u"µs":0.5u"µs":12.0u"µs", 1.0u"µs":0.2u"µs":4.0u"µs",
-7.0u"µs":0.5u"µs":12.0u"µs", 1.0u"µs":0.2u"µs":4.0u"µs", 
-7.0u"µs":0.5u"µs":12.0u"µs", 1.0u"µs":0.2u"µs":4.0u"µs")
+l200 = LegendData(:l200)
+filekey = start_filekey(l200, (:p03, :r000, :cal))
+dsp_config = DSPConfig(dataprod_config(l200).dsp(filekey).default)
 ```
 """
 struct DSPConfig{T <: Real}
@@ -50,10 +47,10 @@ struct DSPConfig{T <: Real}
     inTraceCut_std_threshold::T
 
     # fit window for basline extraction
-    bl_mean::NTuple{2, Quantity{<:T}}
+    bl_window::ClosedInterval{<:Quantity{<:T}}
 
     # fit window for decay time extraction
-    pz_fit::NTuple{2, Quantity{<:T}}
+    tail_window::ClosedInterval{<:Quantity{<:T}}
 
     # ADC threshold for t0 determination
     t0_threshold::T
@@ -75,5 +72,9 @@ struct DSPConfig{T <: Real}
 end
 export DSPConfig
 
+
+function DSPConfig(pd::PropDict)
+    _create_dsp_config(pd)
+end
 
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,7 @@
 # This file is a part of LegendDSP.jl, licensed under the MIT License (MIT).
 
 """
-    create_dsp_config(dsp_metadata::PropDicts.PropDict)
+    _create_dsp_config(dsp_metadata::PropDicts.PropDict)
 
 Create a `DSPConfig` from a `PropDict` of DSP metadata.
 
@@ -11,36 +11,32 @@ Create a `DSPConfig` from a `PropDict` of DSP metadata.
 # Returns
 - `dsp_config::DSPConfig`: DSP configuration
 """
-function create_dsp_config end
-export create_dsp_config
-
-
-function create_dsp_config(dsp_metadata::PropDicts.PropDict)
+function _create_dsp_config(dsp_metadata::PropDicts.PropDict)
     return DSPConfig{Float64}(
         # pick-off time for ENC noise calculations
-        dsp_metadata.enc_pickoff_trap*u"µs",
-        dsp_metadata.enc_pickoff_zac*u"µs",
-        dsp_metadata.enc_pickoff_cusp*u"µs",
+        dsp_metadata.enc_pickoff_trap,
+        dsp_metadata.enc_pickoff_zac,
+        dsp_metadata.enc_pickoff_cusp,
         # filter lengths for CUSP and ZAC filters
-        dsp_metadata.flt_length_cusp*u"µs",
-        dsp_metadata.flt_length_zac*u"µs",
+        dsp_metadata.flt_length_cusp,
+        dsp_metadata.flt_length_zac,
         # in-trace pile-up rejector threshold in sigmas
         dsp_metadata.inTraceCut_std_threshold,
         # fit window for basline extraction
-        (dsp_metadata.bl_mean.min*u"µs", dsp_metadata.bl_mean.max*u"µs"),
+        dsp_metadata.bl_window.min .. dsp_metadata.bl_window.max,
         # fit window for decay time extraction
-        (dsp_metadata.pz_fit.min*u"µs", dsp_metadata.pz_fit.max*u"µs"),
+        dsp_metadata.tail_window.min .. dsp_metadata.tail_window.max,
         # ADC threshold for t0 determination
         dsp_metadata.t0_threshold,
         # rise and flat-top time grid scan ranges for trapezoidal filter
-        dsp_metadata.e_grid_trap.rt.start*u"µs":dsp_metadata.e_grid_trap.rt.step*u"µs":dsp_metadata.e_grid_trap.rt.stop*u"µs",
-        dsp_metadata.e_grid_trap.ft.start*u"µs":dsp_metadata.e_grid_trap.ft.step*u"µs":dsp_metadata.e_grid_trap.ft.stop*u"µs",
+        dsp_metadata.e_grid_trap.rt.start:dsp_metadata.e_grid_trap.rt.step:dsp_metadata.e_grid_trap.rt.stop,
+        dsp_metadata.e_grid_trap.ft.start:dsp_metadata.e_grid_trap.ft.step:dsp_metadata.e_grid_trap.ft.stop,
         # rise and flat-top time grid scan ranges for ZAC filter
-        dsp_metadata.e_grid_zac.rt.start*u"µs":dsp_metadata.e_grid_zac.rt.step*u"µs":dsp_metadata.e_grid_zac.rt.stop*u"µs",
-        dsp_metadata.e_grid_zac.ft.start*u"µs":dsp_metadata.e_grid_zac.ft.step*u"µs":dsp_metadata.e_grid_zac.ft.stop*u"µs",
+        dsp_metadata.e_grid_zac.rt.start:dsp_metadata.e_grid_zac.rt.step:dsp_metadata.e_grid_zac.rt.stop,
+        dsp_metadata.e_grid_zac.ft.start:dsp_metadata.e_grid_zac.ft.step:dsp_metadata.e_grid_zac.ft.stop,
         # rise and flat-top time grid scan ranges for CUSP filter
-        dsp_metadata.e_grid_cusp.rt.start*u"µs":dsp_metadata.e_grid_cusp.rt.step*u"µs":dsp_metadata.e_grid_cusp.rt.stop*u"µs",
-        dsp_metadata.e_grid_cusp.ft.start*u"µs":dsp_metadata.e_grid_cusp.ft.step*u"µs":dsp_metadata.e_grid_cusp.ft.stop*u"µs",
+        dsp_metadata.e_grid_cusp.rt.start:dsp_metadata.e_grid_cusp.rt.step:dsp_metadata.e_grid_cusp.rt.stop,
+        dsp_metadata.e_grid_cusp.ft.start:dsp_metadata.e_grid_cusp.ft.step:dsp_metadata.e_grid_cusp.ft.stop,
         # window length grid scan range for SG filter in current determination
-        dsp_metadata.a_grid_wl_sg.start*u"ns":dsp_metadata.a_grid_wl_sg.step*u"ns":dsp_metadata.a_grid_wl_sg.stop*u"ns")
+        dsp_metadata.a_grid_wl_sg.start:dsp_metadata.a_grid_wl_sg.step:dsp_metadata.a_grid_wl_sg.stop)
 end


### PR DESCRIPTION
A small change to enable the usage of the `dsp_decay_times()` function outside of the JuliaDSP processing.

Just a small change adding multiple dispatch on the function for taking `DSPConfig` as input VS the actual parameters contained in the config itself (tuples `bl_mean` and `pz_fit`).

Example of how I'm using it to extract the decay time constant from data to use in preamp settings for LegendGeSim raw waveform simulation:

```julia
peak = findmax(LegendGeSim._fast_ustrip(raw_table_data.waveform[1].signal))[2]
step = 250
utime = raw_table_data.waveform[1].time
tdecays = LegendDSP.dsp_decay_times(RadiationDetectorDSP.ArrayOfRDWaveforms(raw_table_data.waveform),
    (first(utime), utime[peak-step]),
    (utime[peak+step], utime[end])
)
```

This is possible with the multiple dispatch option I introduced.

I would liked this change to be committed to `main` so that I can share my code that extracts parameters from data needed for simulations with another collaborator who is using LegendGeSim for the same purpose.