### PR TITLE
Replace `RealQuantity` with `Unitful.RealOrRealQuantity`

### DIFF
--- a/src/LegendDSP.jl
+++ b/src/LegendDSP.jl
@@ -29,6 +29,7 @@ import Adapt
 import RadiationDetectorDSP: fltinstance, rdfilt!, flt_output_length, 
     flt_input_smpltype, flt_output_smpltype
 
+using Unitful: RealOrRealQuantity as RealQuantity
 
 include("tailstats.jl")
 include("types.jl")

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,9 +1,5 @@
 # This file is a part of LegendDSP.jl, licensed under the MIT License (MIT).
 
-const MaybeWithUnits{T<:Number} = Union{T,Quantity{<:T}}
-const RealQuantity = MaybeWithUnits{<:Real}
-
-
 """
     DSPConfig{T <: Real}
 


### PR DESCRIPTION
Removes `MaybeWithUnits`, which was neither exported nor used in the package.