### PR TITLE
Bug Fix SiPM DSP

### DIFF
--- a/src/dsp_sipm.jl
+++ b/src/dsp_sipm.jl
@@ -133,8 +133,8 @@ function dsp_sipm_compressed(data::Q, config::PropDict, pars_threshold::PropDict
     t0_hpge_window            = config.t0_hpge_window
 
     # get config parameters
-    threshold    = pars_threshold.sigma_thrs * config.n_sigma_threshold
-    threshold_DC = pars_threshold.sigma_DC * config.n_sigma_dc_threshold
+    threshold    = pars_threshold.trig.σ * config.n_sigma_threshold
+    threshold_DC = pars_threshold.dc.σ * config.n_sigma_dc_threshold
 
     # get waveform data 
     wvfs = decode_data(data.waveform_bit_drop)


### PR DESCRIPTION
Fixed SiPM DSP function to use new filter parameter names for `trig` and `dc` trigger thresholds.