### PR TITLE
Add `extremestats`

### DIFF
--- a/src/LegendDSP.jl
+++ b/src/LegendDSP.jl
@@ -33,6 +33,7 @@ import RadiationDetectorDSP: fltinstance, rdfilt!, flt_output_length,
 using Unitful: RealOrRealQuantity as RealQuantity
 
 include("tailstats.jl")
+include("extremestats.jl")
 include("types.jl")
 include("utils.jl")
 include("derivative.jl")

--- a/src/extremestats.jl
+++ b/src/extremestats.jl
@@ -1,0 +1,40 @@
+# This file is a part of LegendDSP.jl, licensed under the MIT License (MIT).
+
+"""
+    extremestats(signal::AbstractSamples, start::Real, stop::Real)
+    extremestats(signal::RDWaveform, start::RealQuantity, stop::RealQuantity)
+
+Get the extrema and their time positions on `signal` in the interval (`start`,`stop`).
+Output is in the format `(min = .., max = .., tmin = .., tmax = ..)`
+
+"""
+function extremestats end
+export extremestats
+
+function extremestats(input::RadiationDetectorDSP.SamplesOrWaveform, start::RadiationDetectorDSP.RealQuantity, stop::RadiationDetectorDSP.RealQuantity)
+    X_axis, Y = RadiationDetectorDSP._get_axis_and_signal(input)
+    first_x, step_x = first(X_axis), step(X_axis)
+    from = round(Int, ustrip(NoUnits, (start - first_x) / step_x)) + firstindex(X_axis)
+    until = round(Int, ustrip(NoUnits, (stop - first_x) / step_x)) + firstindex(X_axis)
+    _extremestats_impl(X_axis, Y, from:until)
+end
+
+extremestats(input::RadiationDetectorSignals.RDWaveform)  = extremestats(input, first(input.time), last(input.time))
+extremestats(input::RadiationDetectorDSP.AbstractSamples) = extremestats(input, firstindex(input), lastindex(input))
+
+function _extremestats_impl(X::AbstractArray{<:RealQuantity}, Y::AbstractArray{<:RealQuantity}, idxs::AbstractUnitRange{<:Integer})
+    @assert axes(X) == axes(Y)
+    @assert firstindex(X) <= first(idxs) <= last(idxs) <= lastindex(X)
+    @assert firstindex(Y) <= first(idxs) <= last(idxs) <= lastindex(Y)
+    
+    minv, minidx = findmin(view(Y, idxs))
+    maxv, maxidx = findmax(view(Y, idxs))
+    
+    (
+        min = minv,
+        max = maxv,
+        tmin = X[minidx + first(idxs) - begin],
+        tmax = X[maxidx + first(idxs) - begin]
+    )
+
+end

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -1,0 +1,53 @@
+# This file is a part of LegendDSP.jl, licensed under the MIT License (MIT).
+
+using Test
+using LegendDSP
+using RadiationDetectorSignals
+using Unitful
+
+@testset "Test extremestats" begin
+    
+    @testset "Test single waveform" begin
+        wf = RDWaveform((0:1:360)u"ns", sind.(0:360))
+
+        es_full = extremestats(wf)
+        @test es_full.min  == -1.0
+        @test es_full.max  ==  1.0
+        @test es_full.tmin ==  270u"ns"
+        @test es_full.tmax ==   90u"ns"
+
+        es_part = extremestats(wf, 0u"ns", 180u"ns")
+        @test es_part.min  == 0.0
+        @test es_part.max  == 1.0
+        @test es_part.tmin ==   0u"ns"
+        @test es_part.tmax ==  90u"ns"
+
+        es_part2 = extremestats(wf, 135u"ns", 225u"ns")
+        @test es_part2.min  == -sqrt(0.5)
+        @test es_part2.max  ==  sqrt(0.5)
+        @test es_part2.tmin == 225u"ns"
+        @test es_part2.tmax == 135u"ns"
+    end
+    
+    @testset "Test single array" begin
+        wf = sind.(1:360)
+        
+        es_full = extremestats(wf)
+        @test es_full.min  == -1.0
+        @test es_full.max  ==  1.0
+        @test es_full.tmin ==  270
+        @test es_full.tmax ==   90
+
+        es_part = extremestats(wf, 180, 360)
+        @test es_part.min  == -1.0
+        @test es_part.max  ==  0.0
+        @test es_part.tmin ==  270
+        @test es_part.tmax ==  180
+
+        es_part2 = extremestats(wf, 135, 225)
+        @test es_part2.min  == -sqrt(0.5)
+        @test es_part2.max  ==  sqrt(0.5)
+        @test es_part2.tmin == 225
+        @test es_part2.tmax == 135
+    end
+end


### PR DESCRIPTION
This takes a waveform or an array and determines the extrema (`min`, `max`) and their time values / indices (`tmin`, `tmax`).

Example:
```julia
using LegendDSP
using RadiationDetectorSignals
using Unitful

wf = RDWaveform((0:1:360)u"ns", sind.(0:360))
extremestats(wf)
```
```
(min = -1.0, max = 1.0, tmin = 270 ns, tmax = 90 ns)
```

Just like `signalstats` and `tailstats`, you can pass `start` and `stop`, but it is not required (see tests).
