### PR TITLE
Add `thresholdstats`

### DIFF
--- a/src/LegendDSP.jl
+++ b/src/LegendDSP.jl
@@ -34,6 +34,7 @@ using Unitful: RealOrRealQuantity as RealQuantity
 
 include("tailstats.jl")
 include("extremestats.jl")
+include("thresholdstats.jl")
 include("types.jl")
 include("utils.jl")
 include("derivative.jl")

--- a/src/thresholdstats.jl
+++ b/src/thresholdstats.jl
@@ -1,0 +1,41 @@
+# This file is a part of LegendDSP.jl, licensed under the MIT License (MIT).
+
+"""
+    thresholdstats(signal::AbstractSamples, min::Real, min::Real)
+    thresholdstats(signal::RDWaveform, min::RealQuantity, max::RealQuantity)
+
+Get the standard deviation of all samples in a `signal` that are within 
+the lower bound `min` and the upper bound `max`.
+If no values for `min` or `max` are passed, the respective bound is ignored.
+"""
+function thresholdstats end
+export thresholdstats
+
+function thresholdstats(input::RadiationDetectorDSP.SamplesOrWaveform{T}, min::RadiationDetectorDSP.RealQuantity = -Inf * unit(T), max::RadiationDetectorDSP.RealQuantity = Inf * unit(T)) where T
+    _, Y = RadiationDetectorDSP._get_axis_and_signal(input)
+    _thresholdstats_impl(Y, T(min), T(max))
+end
+
+function _thresholdstats_impl(Y::AbstractArray{T}, _min::T, _max::T) where {T <: RealQuantity}
+        
+    zy = zero(eltype(Y))
+
+    sum_Y::float(typeof(zy)) = zy
+    sum_Y_sqr::float(typeof(zy * zy)) = zy * zy
+    n::Int = 0
+
+    @inbounds @fastmath @simd for i in eachindex(Y)
+        y = Y[i]
+        _include = _min <= y <= _max
+        y = _include * y
+        sum_Y = y + sum_Y
+        sum_Y_sqr = fma(y, y, sum_Y_sqr)
+        n += _include
+    end
+    
+    inv_n = inv(n)
+    mean_Y = sum_Y * inv_n
+    var_Y = max(sum_Y_sqr * inv_n - mean_Y * mean_Y, zero(sum_Y_sqr))
+    sqrt(var_Y)
+
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -3,6 +3,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 RadiationDetectorDSP = "afd6e06f-c550-5763-af36-7391d39e46ec"
 RadiationDetectorSignals = "bf2c0563-65cf-5db2-a620-ceb7de82658c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 


### PR DESCRIPTION
The new function `thresholdstats` takes a waveform as input and returns its standard deviation.
There are two arguments `min` and `max` that can be used to set lower and upper bounds to exclude outliers.
By default, these outliers are not excluded.

I tested this "by eye" on real waveforms and the result looks reasonable:
```julia
σ = thresholdstats(wf)
plot(wf, label = "waveform")
hline!([-σ,σ], label = "thresholdstats", lw = 2)
```
![image](https://github.com/user-attachments/assets/42b0844c-7636-4578-a77c-74d47599dc45)

In addition, I wrote some tests that generates random waveforms based on some given standard deviation `σ`  and compares the output to the given `σ`, as well as to the output of
```julia
compare(wf::RDWaveform{<:Any,T}, _min, _max) where {T} = std(wf.signal[_min .<= wf.signal .<= _max])
```
which does what we want, but in a slower way.