### PR TITLE
Update codecov CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,9 @@ jobs:
       - uses: codecov/codecov-action@v5
         if: matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64'
         with:
-          file: lcov.info
+          files: lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   docs:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
After upgrading to [codecov v5](https://github.com/codecov/codecov-action?tab=readme-ov-file#v5-release) in #42, the codecov CI was not able to upload the codecov result without a token.
In addition, the argument `file` was deprecated in favor of `files`.
I updated the outdated CI workflow file in this PR.