### PR TITLE
Add trap filter pipeline to SiPM DSP and restructure config

### DIFF
--- a/src/dsp_sipm.jl
+++ b/src/dsp_sipm.jl
@@ -19,10 +19,30 @@ The output data is a table with the following columns:
 - `timestamp`: timestamp
 - `eventID_fadc`: event number from FADC
 - `e_fc`: energy from FADC
-- `trig_pos`: trigger positions from DSP
-- `trig_max`: trigger maxima from DSP
-- `trig_pos_DC`: trigger positions of discharges
-- `trig_max_DC`: trigger maxima of discharges
+- `t_max`, `t_min`: time of waveform maximum/minimum
+- `t_max_lar`, `t_min_lar`: time of waveform maximum/minimum in LAr window
+- `e_max`, `e_min`: waveform maximum/minimum amplitude
+- `e_max_lar`, `e_min_lar`: waveform maximum/minimum amplitude in LAr window
+- `blmean`, `blsigma`, `blslope`, `bloffset`: baseline statistics
+- `wfmean`, `wfsigma`, `wfslope`, `wfoffset`: waveform statistics
+## SG filter columns
+- `threshold`: SG trigger threshold
+- `threshold_DC`: SG discharge trigger threshold
+- `trig_pos`: SG trigger positions
+- `trig_max`: SG trigger maxima
+- `trig_pos_DC`: SG discharge trigger positions
+- `trig_max_DC`: SG discharge trigger maxima
+## Trap filter columns
+- `threshold_trap`: trap trigger threshold
+- `threshold_DC_trap`: trap discharge trigger threshold
+- `trig_pos_trap`: trap trigger positions
+- `trig_pos_high_trap`: trap trigger high positions
+- `trig_pos_tot_trap`: trap trigger time-over-threshold positions
+- `trig_max_trap`: trap trigger maxima
+- `trig_pos_DC_trap`: trap discharge trigger positions
+- `trig_pos_high_DC_trap`: trap discharge trigger high positions
+- `trig_pos_tot_DC_trap`: trap discharge trigger time-over-threshold positions
+- `trig_max_DC_trap`: trap discharge trigger maxima
 """
 function dsp_sipm(data::Q, config::PropDict, pars_optimization::PropDict) where {Q <: Table}
     # common config
@@ -109,13 +129,13 @@ function dsp_sipm(data::Q, config::PropDict, pars_optimization::PropDict) where 
     wvfs_trap = trap_filter.(wvfs_pz)
 
     # trigger finding on trap-filtered waveforms
-    intflt_trap = IntersectMaximum(trap_min_tot_intersect, trap_max_tot_intersect)
+    intflt_trap = IntersectMaximum(min_tot_intersect, max_tot_intersect)
     inters_thres_trap = thresholdstats_mad.(wvfs_trap, trap_min_threshold, trap_max_threshold)
     inters_trap = intflt_trap.(wvfs_trap, trap_n_σ_threshold .* inters_thres_trap)
 
     # discharge detection on flipped integrated waveforms 
     inters_thres_DC_trap = thresholdstats_mad.(wvfs_int_flip, trap_min_dc_threshold, trap_max_dc_threshold)
-    inters_DC_trap = intflt_sg.(wvfs_int_flip, trap_n_σ_dc_threshold .* inters_thres_DC_trap)
+    inters_DC_trap = intflt_trap.(wvfs_int_flip, trap_n_σ_dc_threshold .* inters_thres_DC_trap)
 
     # output Table 
     return TypedTables.Table(
@@ -159,10 +179,30 @@ The output data is a table with the following columns:
 - `timestamp`: timestamp
 - `eventID_fadc`: event number from FADC
 - `e_fc`: energy from FADC
-- `trig_pos`: trigger positions from DSP
-- `trig_max`: trigger maxima from DSP
-- `trig_pos_DC`: trigger positions of discharges
-- `trig_max_DC`: trigger maxima of discharges
+- `t_max`, `t_min`: time of waveform maximum/minimum
+- `t_max_lar`, `t_min_lar`: time of waveform maximum/minimum in LAr window
+- `e_max`, `e_min`: waveform maximum/minimum amplitude
+- `e_max_lar`, `e_min_lar`: waveform maximum/minimum amplitude in LAr window
+- `blmean`, `blsigma`, `blslope`, `bloffset`: baseline statistics
+- `wfmean`, `wfsigma`, `wfslope`, `wfoffset`: waveform statistics
+## SG filter columns
+- `threshold`: SG trigger threshold
+- `threshold_DC`: SG discharge trigger threshold
+- `trig_pos`: SG trigger positions
+- `trig_max`: SG trigger maxima
+- `trig_pos_DC`: SG discharge trigger positions
+- `trig_max_DC`: SG discharge trigger maxima
+## Trap filter columns
+- `threshold_trap`: trap trigger threshold
+- `threshold_DC_trap`: trap discharge trigger threshold
+- `trig_pos_trap`: trap trigger positions
+- `trig_pos_high_trap`: trap trigger high positions
+- `trig_pos_tot_trap`: trap trigger time-over-threshold positions
+- `trig_max_trap`: trap trigger maxima
+- `trig_pos_DC_trap`: trap discharge trigger positions
+- `trig_pos_high_DC_trap`: trap discharge trigger high positions
+- `trig_pos_tot_DC_trap`: trap discharge trigger time-over-threshold positions
+- `trig_max_DC_trap`: trap discharge trigger maxima
 """
 function dsp_sipm_compressed(data::Q, config::PropDict, pars_optimization::PropDict) where {Q <: Table}
     # common config
@@ -255,7 +295,7 @@ function dsp_sipm_compressed(data::Q, config::PropDict, pars_optimization::PropD
 
     # discharge detection on flipped integrated waveforms 
     inters_thres_DC_trap = thresholdstats_mad.(wvfs_int_flip, trap_min_dc_threshold, trap_max_dc_threshold)
-    inters_DC_trap = intflt_sg.(wvfs_int_flip, trap_n_σ_dc_threshold .* inters_thres_DC_trap)
+    inters_DC_trap = intflt_trap.(wvfs_int_flip, trap_n_σ_dc_threshold .* inters_thres_DC_trap)
 
     # output Table 
     return TypedTables.Table(

--- a/src/dsp_sipm.jl
+++ b/src/dsp_sipm.jl
@@ -25,17 +25,34 @@ The output data is a table with the following columns:
 - `trig_max_DC`: trigger maxima of discharges
 """
 function dsp_sipm(data::Q, config::PropDict, pars_optimization::PropDict) where {Q <: Table}
-    # get dsp meta parameters
-    min_tot_intersect     = config.min_tot_intersect
-    max_tot_intersect     = config.max_tot_intersect
+    # common config
     sg_flt_degree         = config.sg_flt_degree
     t0_hpge_window        = config.t0_hpge_window
-    min_threshold         = config.min_threshold
-    max_threshold         = config.max_threshold
-    n_σ_threshold         = config.n_σ_threshold
-    min_dc_threshold      = config.min_dc_threshold
-    max_dc_threshold      = config.max_dc_threshold
-    n_σ_dc_threshold      = config.n_σ_dc_threshold
+
+    # get SG config parameters
+    sg_config = config.filters.sg
+    min_tot_intersect     = sg_config.min_tot_intersect
+    max_tot_intersect     = sg_config.max_tot_intersect
+    min_threshold         = sg_config.min_threshold
+    max_threshold         = sg_config.max_threshold
+    n_σ_threshold         = sg_config.n_σ_threshold
+    min_dc_threshold      = sg_config.min_dc_threshold
+    max_dc_threshold      = sg_config.max_dc_threshold
+    n_σ_dc_threshold      = sg_config.n_σ_dc_threshold
+
+    # get trap config parameters
+    trap_config = config.filters.trap
+    trap_rt                = trap_config.rt
+    trap_ft                = trap_config.ft
+    trap_pz_tau            = trap_config.pz_tau
+    trap_min_tot_intersect = trap_config.min_tot_intersect
+    trap_max_tot_intersect = trap_config.max_tot_intersect
+    trap_min_threshold     = trap_config.min_threshold
+    trap_max_threshold     = trap_config.max_threshold
+    trap_n_σ_threshold     = trap_config.n_σ_threshold
+    trap_min_dc_threshold  = trap_config.min_dc_threshold
+    trap_max_dc_threshold  = trap_config.max_dc_threshold
+    trap_n_σ_dc_threshold  = trap_config.n_σ_dc_threshold
 
     # unpack optimization parameters
     sg_window_length = pars_optimization.sg.wl
@@ -47,7 +64,7 @@ function dsp_sipm(data::Q, config::PropDict, pars_optimization::PropDict) where 
     evID = data.eventnumber
     efc  = data.daqenergy
 
-    # shift waveform by 0 to get Float64 conversation --> ToDO: check if this is necessary
+    # shift waveform by 0 to get Float64 conversion
     wvfs = shift_waveform.(wvfs, 0.0)
 
     # get wvf maximum and minimum with timepoints
@@ -57,41 +74,66 @@ function dsp_sipm(data::Q, config::PropDict, pars_optimization::PropDict) where 
     uflt_trunc = TruncateFilter(first(t0_hpge_window)..last(t0_hpge_window))
     estats_trunc = extremestats.(uflt_trunc.(wvfs))
 
+    # === SG pipeline ===
     # savitzky golay filter: takes derivative of waveform plus smoothing
     sgflt_savitz = SavitzkyGolayFilter(sg_window_length, sg_flt_degree, 1)
-    wvfs = sgflt_savitz.(wvfs)
+    wvfs_sg = sgflt_savitz.(wvfs)
 
-    # maximum finder
-    intflt = IntersectMaximum(min_tot_intersect, max_tot_intersect)
-    inters_thres = thresholdstats.(wvfs, min_threshold, max_threshold)
-    inters = intflt.(wvfs, n_σ_threshold .* inters_thres)
+    # trigger finding on SG-filtered waveforms
+    intflt_sg = IntersectMaximum(min_tot_intersect, max_tot_intersect)
+    inters_thres = thresholdstats_mad.(wvfs_sg, min_threshold, max_threshold)
+    inters = intflt_sg.(wvfs_sg, n_σ_threshold .* inters_thres)
 
-    # remove discharges
     # integrate derivative
     integrator_filter = IntegratorFilter(gain=1)
-    wvfs = integrator_filter.(wvfs)
+    wvfs_int = integrator_filter.(wvfs_sg)
 
-    # get blstats on derivative
-    time_min = minimum(wvfs[1].time)
-    Δt = 3*step(wvfs[1].time)
-    bl_stats = signalstats.(wvfs, Ref(time_min), ifelse.(minimum.(inters.x; init=0u"s") .< time_min + Δt, time_min + Δt, minimum.(inters.x; init=0u"s")))
-    sigstats = signalstats.(wvfs, time_min, last(wvfs[1].time))
+    # get blstats on integrated waveforms
+    time_min = minimum(wvfs_int[1].time)
+    Δt = 3*step(wvfs_int[1].time)
+    bl_stats = signalstats.(wvfs_int, Ref(time_min), ifelse.(minimum.(inters.x; init=0u"s") .< time_min + Δt, time_min + Δt, minimum.(inters.x; init=0u"s")))
+    sigstats = signalstats.(wvfs_int, time_min, last(wvfs_int[1].time))
     
-    # flip around x-axis the filtered waveforms
-    wvfs = multiply_waveform.(wvfs, -1.0)
-    inters_thres_DC = thresholdstats.(wvfs, min_dc_threshold, max_dc_threshold)
-    inters_DC = intflt.(wvfs, n_σ_dc_threshold .* inters_thres_DC)
+    # flip around x-axis for discharge detection
+    wvfs_int_flip = multiply_waveform.(wvfs_int, -1.0)
+    inters_thres_DC = thresholdstats_mad.(wvfs_int_flip, min_dc_threshold, max_dc_threshold)
+    inters_DC = intflt_sg.(wvfs_int_flip, n_σ_dc_threshold .* inters_thres_DC)
+
+    # === Trap pipeline ===
+    # PZ correction on integrated waveforms
+    pz_filter = InvCRFilter(trap_pz_tau)
+    wvfs_pz = pz_filter.(wvfs_int)
+
+    # trapezoidal charge filter
+    trap_filter = TrapezoidalChargeFilter(trap_rt, trap_ft)
+    wvfs_trap = trap_filter.(wvfs_pz)
+
+    # trigger finding on trap-filtered waveforms
+    intflt_trap = IntersectMaximum(trap_min_tot_intersect, trap_max_tot_intersect)
+    inters_thres_trap = thresholdstats_mad.(wvfs_trap, trap_min_threshold, trap_max_threshold)
+    inters_trap = intflt_trap.(wvfs_trap, trap_n_σ_threshold .* inters_thres_trap)
+
+    # discharge detection on flipped integrated waveforms 
+    inters_thres_DC_trap = thresholdstats_mad.(wvfs_int_flip, trap_min_dc_threshold, trap_max_dc_threshold)
+    inters_DC_trap = intflt_sg.(wvfs_int_flip, trap_n_σ_dc_threshold .* inters_thres_DC_trap)
 
     # output Table 
     return TypedTables.Table(
         blfc = blfc, timestamp = ts, eventID_fadc = evID, e_fc = efc,
         t_max = uconvert.(u"µs", estats.tmax), t_min = uconvert.(u"µs", estats.tmin), t_max_lar = uconvert.(u"µs", estats_trunc.tmax), t_min_lar = uconvert.(u"µs", estats_trunc.tmin),
-        e_max = wvfs_max, e_min = wvfs_min, e_max_lar = wvfs_trunc_max, e_min_lar = wvfs_trunc_min,
+        e_max = estats.max, e_min = estats.min, e_max_lar = estats_trunc.max, e_min_lar = estats_trunc.min,
         blmean = bl_stats.mean, blsigma = bl_stats.sigma, blslope = bl_stats.slope, bloffset = bl_stats.offset, 
         wfmean = sigstats.mean, wfsigma = sigstats.sigma, wfslope = sigstats.slope, wfoffset = sigstats.offset,
+        # SG triggers
         threshold = inters_thres, threshold_DC = inters_thres_DC,
-        trig_pos =  VectorOfVectors(inters.x), trig_max =  VectorOfVectors(inters.max),
-        trig_pos_DC =  VectorOfVectors(inters_DC.x), trig_max_DC =  VectorOfVectors(inters_DC.max)
+        trig_pos = VectorOfVectors(inters.x), trig_max = VectorOfVectors(inters.max),
+        trig_pos_DC = VectorOfVectors(inters_DC.x), trig_max_DC = VectorOfVectors(inters_DC.max),
+        # Trap triggers
+        threshold_trap = inters_thres_trap, threshold_DC_trap = inters_thres_DC_trap,
+        trig_pos_trap = VectorOfVectors(inters_trap.x), trig_pos_high_trap = VectorOfVectors(inters_trap.x_high),
+        trig_pos_tot_trap = VectorOfVectors(inters_trap.x_tot), trig_max_trap = VectorOfVectors(inters_trap.max),
+        trig_pos_DC_trap = VectorOfVectors(inters_DC_trap.x), trig_pos_high_DC_trap = VectorOfVectors(inters_DC_trap.x_high),
+        trig_pos_tot_DC_trap = VectorOfVectors(inters_DC_trap.x_tot), trig_max_DC_trap = VectorOfVectors(inters_DC_trap.max)
     )
 end
 export dsp_sipm
@@ -123,17 +165,34 @@ The output data is a table with the following columns:
 - `trig_max_DC`: trigger maxima of discharges
 """
 function dsp_sipm_compressed(data::Q, config::PropDict, pars_optimization::PropDict) where {Q <: Table}
-    # get dsp meta parameters
-    min_tot_intersect     = config.min_tot_intersect
-    max_tot_intersect     = config.max_tot_intersect
+    # common config
     sg_flt_degree         = config.sg_flt_degree
     t0_hpge_window        = config.t0_hpge_window
-    min_threshold         = config.min_threshold
-    max_threshold         = config.max_threshold
-    n_σ_threshold         = config.n_σ_threshold
-    min_dc_threshold      = config.min_dc_threshold
-    max_dc_threshold      = config.max_dc_threshold
-    n_σ_dc_threshold      = config.n_σ_dc_threshold
+
+    # get SG config parameters
+    sg_config = config.filters.sg
+    min_tot_intersect     = sg_config.min_tot_intersect
+    max_tot_intersect     = sg_config.max_tot_intersect
+    min_threshold         = sg_config.min_threshold
+    max_threshold         = sg_config.max_threshold
+    n_σ_threshold         = sg_config.n_σ_threshold
+    min_dc_threshold      = sg_config.min_dc_threshold
+    max_dc_threshold      = sg_config.max_dc_threshold
+    n_σ_dc_threshold      = sg_config.n_σ_dc_threshold
+
+    # get trap config parameters
+    trap_config = config.filters.trap
+    trap_rt                = trap_config.rt
+    trap_ft                = trap_config.ft
+    trap_pz_tau            = trap_config.pz_tau
+    trap_min_tot_intersect = trap_config.min_tot_intersect
+    trap_max_tot_intersect = trap_config.max_tot_intersect
+    trap_min_threshold     = trap_config.min_threshold
+    trap_max_threshold     = trap_config.max_threshold
+    trap_n_σ_threshold     = trap_config.n_σ_threshold
+    trap_min_dc_threshold  = trap_config.min_dc_threshold
+    trap_max_dc_threshold  = trap_config.max_dc_threshold
+    trap_n_σ_dc_threshold  = trap_config.n_σ_dc_threshold
 
     # unpack optimization parameters
     sg_window_length = pars_optimization.sg.wl
@@ -145,7 +204,7 @@ function dsp_sipm_compressed(data::Q, config::PropDict, pars_optimization::PropD
     evID = data.eventnumber
     efc  = data.daqenergy
 
-    # shift waveform by 0 to get Float64 conversation --> ToDO: check if this is necessary
+    # shift waveform by 0 to get Float64 conversion
     wvfs = shift_waveform.(wvfs, 0.0)
 
     # get wvf maximum and minimum with timepoints
@@ -155,30 +214,48 @@ function dsp_sipm_compressed(data::Q, config::PropDict, pars_optimization::PropD
     uflt_trunc = TruncateFilter(first(t0_hpge_window)..last(t0_hpge_window))
     estats_trunc = extremestats.(uflt_trunc.(wvfs))
 
+    # === SG pipeline ===
     # savitzky golay filter: takes derivative of waveform plus smoothing
     sgflt_savitz = SavitzkyGolayFilter(sg_window_length, sg_flt_degree, 1)
-    wvfs = sgflt_savitz.(wvfs)
+    wvfs_sg = sgflt_savitz.(wvfs)
 
-    # maximum finder
-    intflt = IntersectMaximum(min_tot_intersect, max_tot_intersect)
-    inters_thres = thresholdstats.(wvfs, min_threshold, max_threshold)
-    inters = intflt.(wvfs, n_σ_threshold .* inters_thres)
+    # trigger finding on SG-filtered waveforms
+    intflt_sg = IntersectMaximum(min_tot_intersect, max_tot_intersect)
+    inters_thres = thresholdstats_mad.(wvfs_sg, min_threshold, max_threshold)
+    inters = intflt_sg.(wvfs_sg, n_σ_threshold .* inters_thres)
 
-    # remove discharges
     # integrate derivative
     integrator_filter = IntegratorFilter(gain=1)
-    wvfs = integrator_filter.(wvfs)
+    wvfs_int = integrator_filter.(wvfs_sg)
 
-    # get blstats on derivative
-    time_min = minimum(wvfs[1].time)
-    Δt = 3*step(wvfs[1].time)
-    bl_stats = signalstats.(wvfs, Ref(time_min), ifelse.(minimum.(inters.x; init=0u"s") .< time_min + Δt, time_min + Δt, minimum.(inters.x; init=0u"s")))
-    sigstats = signalstats.(wvfs, time_min, last(wvfs[1].time))
+    # get blstats on integrated waveforms
+    time_min = minimum(wvfs_int[1].time)
+    Δt = 3*step(wvfs_int[1].time)
+    bl_stats = signalstats.(wvfs_int, Ref(time_min), ifelse.(minimum.(inters.x; init=0u"s") .< time_min + Δt, time_min + Δt, minimum.(inters.x; init=0u"s")))
+    sigstats = signalstats.(wvfs_int, time_min, last(wvfs_int[1].time))
     
-    # flip around x-axis the filtered waveforms
-    wvfs = multiply_waveform.(wvfs, -1.0)
-    inters_thres_DC = thresholdstats.(wvfs, min_dc_threshold, max_dc_threshold)
-    inters_DC = intflt.(wvfs, n_σ_dc_threshold .* inters_thres_DC)
+    # flip around x-axis for discharge detection
+    wvfs_int_flip = multiply_waveform.(wvfs_int, -1.0)
+    inters_thres_DC = thresholdstats_mad.(wvfs_int_flip, min_dc_threshold, max_dc_threshold)
+    inters_DC = intflt_sg.(wvfs_int_flip, n_σ_dc_threshold .* inters_thres_DC)
+
+    # === Trap pipeline ===
+    # PZ correction on integrated waveforms
+    pz_filter = InvCRFilter(trap_pz_tau)
+    wvfs_pz = pz_filter.(wvfs_int)
+
+    # trapezoidal charge filter
+    trap_filter = TrapezoidalChargeFilter(trap_rt, trap_ft)
+    wvfs_trap = trap_filter.(wvfs_pz)
+
+    # trigger finding on trap-filtered waveforms
+    intflt_trap = IntersectMaximum(trap_min_tot_intersect, trap_max_tot_intersect)
+    inters_thres_trap = thresholdstats_mad.(wvfs_trap, trap_min_threshold, trap_max_threshold)
+    inters_trap = intflt_trap.(wvfs_trap, trap_n_σ_threshold .* inters_thres_trap)
+
+    # discharge detection on flipped integrated waveforms 
+    inters_thres_DC_trap = thresholdstats_mad.(wvfs_int_flip, trap_min_dc_threshold, trap_max_dc_threshold)
+    inters_DC_trap = intflt_sg.(wvfs_int_flip, trap_n_σ_dc_threshold .* inters_thres_DC_trap)
 
     # output Table 
     return TypedTables.Table(
@@ -187,9 +264,16 @@ function dsp_sipm_compressed(data::Q, config::PropDict, pars_optimization::PropD
         e_max = estats.max, e_min = estats.min, e_max_lar = estats_trunc.max, e_min_lar = estats_trunc.min,
         blmean = bl_stats.mean, blsigma = bl_stats.sigma, blslope = bl_stats.slope, bloffset = bl_stats.offset, 
         wfmean = sigstats.mean, wfsigma = sigstats.sigma, wfslope = sigstats.slope, wfoffset = sigstats.offset,
+        # SG triggers
         threshold = inters_thres, threshold_DC = inters_thres_DC,
-        trig_pos =  VectorOfVectors(inters.x), trig_max =  VectorOfVectors(inters.max),
-        trig_pos_DC =  VectorOfVectors(inters_DC.x), trig_max_DC =  VectorOfVectors(inters_DC.max)
+        trig_pos = VectorOfVectors(inters.x), trig_max = VectorOfVectors(inters.max),
+        trig_pos_DC = VectorOfVectors(inters_DC.x), trig_max_DC = VectorOfVectors(inters_DC.max),
+        # Trap triggers
+        threshold_trap = inters_thres_trap, threshold_DC_trap = inters_thres_DC_trap,
+        trig_pos_trap = VectorOfVectors(inters_trap.x), trig_pos_high_trap = VectorOfVectors(inters_trap.x_high),
+        trig_pos_tot_trap = VectorOfVectors(inters_trap.x_tot), trig_max_trap = VectorOfVectors(inters_trap.max),
+        trig_pos_DC_trap = VectorOfVectors(inters_DC_trap.x), trig_pos_high_DC_trap = VectorOfVectors(inters_DC_trap.x_high),
+        trig_pos_tot_DC_trap = VectorOfVectors(inters_DC_trap.x_tot), trig_max_DC_trap = VectorOfVectors(inters_DC_trap.max)
     )
 end
 export dsp_sipm_compressed

--- a/src/dsp_sipm.jl
+++ b/src/dsp_sipm.jl
@@ -131,11 +131,11 @@ function dsp_sipm(data::Q, config::PropDict, pars_optimization::PropDict) where 
     # trigger finding on trap-filtered waveforms
     intflt_trap = IntersectMaximum(trap_min_tot_intersect, trap_max_tot_intersect)
     inters_thres_trap = thresholdstats_mad.(wvfs_trap, trap_min_threshold, trap_max_threshold)
-    inters_trap = intflt_sg.(wvfs_trap, trap_n_σ_threshold .* inters_thres_trap)
+    inters_trap = intflt_trap.(wvfs_trap, trap_n_σ_threshold .* inters_thres_trap)
 
     # discharge detection on flipped integrated waveforms 
     inters_thres_DC_trap = thresholdstats_mad.(wvfs_int_flip, trap_min_dc_threshold, trap_max_dc_threshold)
-    inters_DC_trap = intflt_trap.(wvfs_int_flip, trap_n_σ_dc_threshold .* inters_thres_DC_trap)
+    inters_DC_trap = intflt_sg.(wvfs_int_flip, trap_n_σ_dc_threshold .* inters_thres_DC_trap)
 
     # output Table 
     return TypedTables.Table(

--- a/src/dsp_sipm.jl
+++ b/src/dsp_sipm.jl
@@ -129,9 +129,9 @@ function dsp_sipm(data::Q, config::PropDict, pars_optimization::PropDict) where 
     wvfs_trap = trap_filter.(wvfs_pz)
 
     # trigger finding on trap-filtered waveforms
-    intflt_trap = IntersectMaximum(min_tot_intersect, max_tot_intersect)
+    intflt_trap = IntersectMaximum(trap_min_tot_intersect, trap_max_tot_intersect)
     inters_thres_trap = thresholdstats_mad.(wvfs_trap, trap_min_threshold, trap_max_threshold)
-    inters_trap = intflt_trap.(wvfs_trap, trap_n_σ_threshold .* inters_thres_trap)
+    inters_trap = intflt_sg.(wvfs_trap, trap_n_σ_threshold .* inters_thres_trap)
 
     # discharge detection on flipped integrated waveforms 
     inters_thres_DC_trap = thresholdstats_mad.(wvfs_int_flip, trap_min_dc_threshold, trap_max_dc_threshold)
@@ -295,7 +295,7 @@ function dsp_sipm_compressed(data::Q, config::PropDict, pars_optimization::PropD
 
     # discharge detection on flipped integrated waveforms 
     inters_thres_DC_trap = thresholdstats_mad.(wvfs_int_flip, trap_min_dc_threshold, trap_max_dc_threshold)
-    inters_DC_trap = intflt_trap.(wvfs_int_flip, trap_n_σ_dc_threshold .* inters_thres_DC_trap)
+    inters_DC_trap = intflt_sg.(wvfs_int_flip, trap_n_σ_dc_threshold .* inters_thres_DC_trap)
 
     # output Table 
     return TypedTables.Table(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,5 +13,6 @@ Test.@testset "Package LegendDSP" begin
     include("test_alternative_filters.jl")
     include("test_dsp_icpc.jl")
     include("test_thresholdstats.jl")
+    include("test_dsp_sipm.jl")
     isempty(Test.detect_ambiguities(LegendDSP))
 end # testset

--- a/test/test_dsp_sipm.jl
+++ b/test/test_dsp_sipm.jl
@@ -1,0 +1,114 @@
+using Test
+using LegendDSP
+using RadiationDetectorSignals
+using RadiationDetectorDSP
+using Unitful
+using TypedTables
+using PropDicts
+using StructArrays
+
+function make_sipm_waveform(n=6250)
+    t = (0:n-1) .* 16.0u"ns"
+    signal = zeros(Float64, n)
+    # flat baseline with a small SiPM-like pulse around 50µs
+    pulse_start = round(Int, 50e3 / 16)  # ~3125
+    pulse_width = 10
+    amplitude = 5.0
+    τ_samples = 30.0
+    for i in 1:n
+        if pulse_start <= i < pulse_start + pulse_width
+            signal[i] = amplitude * (1 - exp(-(i - pulse_start) / 3.0))
+        elseif i >= pulse_start + pulse_width
+            signal[i] = amplitude * exp(-(i - pulse_start - pulse_width) / τ_samples)
+        end
+    end
+    RDWaveform(t, signal)
+end
+
+function make_sipm_data(N=10)
+    Table(
+        waveform    = StructArray([make_sipm_waveform() for _ in 1:N]),
+        baseline    = fill(0.0f0, N),
+        timestamp   = fill(UInt64(0), N),
+        eventnumber = UInt32.(1:N),
+        daqenergy   = fill(UInt16(0), N),
+    )
+end
+
+function make_sipm_config()
+    PropDict(
+        :t0_hpge_window => [47.0u"µs", 53.0u"µs"],
+        :sg_flt_degree  => 3,
+        :filters => PropDict(
+            :sg => PropDict(
+                :n_σ_threshold     => 3.0,
+                :min_threshold     => -1.0,
+                :max_threshold     => 1.0,
+                :n_σ_dc_threshold  => 5.0,
+                :min_dc_threshold  => -4.0,
+                :max_dc_threshold  => 4.0,
+                :min_tot_intersect => 70.0u"ns",
+                :max_tot_intersect => 150.0u"ns",
+            ),
+            :trap => PropDict(
+                :rt                => 100.0u"ns",
+                :ft                => 50.0u"ns",
+                :pz_tau            => 3.0u"µs",
+                :n_σ_threshold     => 3.5,
+                :min_threshold     => -1.5,
+                :max_threshold     => 1.5,
+                :n_σ_dc_threshold  => 5.0,
+                :min_dc_threshold  => -3.0,
+                :max_dc_threshold  => 3.0,
+                :min_tot_intersect => 48.0u"ns",
+                :max_tot_intersect => 250.0u"ns",
+            ),
+        ),
+    )
+end
+
+@testset "dsp_sipm" begin
+    data = make_sipm_data()
+    config = make_sipm_config()
+    pars_opt = PropDict(:sg => PropDict(:wl => 200.0u"ns"))
+
+    result = dsp_sipm(data, config, pars_opt)
+
+    # check that result is a Table with the right number of rows
+    @test result isa TypedTables.Table
+    @test length(result) == 10
+
+    # check all expected output columns exist
+    expected_keys = [:blfc, :timestamp, :eventID_fadc, :e_fc,
+        :t_max, :t_min, :t_max_lar, :t_min_lar,
+        :e_max, :e_min, :e_max_lar, :e_min_lar,
+        :blmean, :blsigma, :blslope, :bloffset,
+        :wfmean, :wfsigma, :wfslope, :wfoffset,
+        :threshold, :threshold_DC,
+        :trig_pos, :trig_max, :trig_pos_DC, :trig_max_DC,
+        :threshold_trap, :threshold_DC_trap,
+        :trig_pos_trap, :trig_pos_high_trap, :trig_pos_tot_trap, :trig_max_trap,
+        :trig_pos_DC_trap, :trig_pos_high_DC_trap, :trig_pos_tot_DC_trap, :trig_max_DC_trap]
+    for k in expected_keys
+        @test hasproperty(result, k)
+    end
+
+    # basic sanity: timestamps and event IDs passed through
+    @test all(result.timestamp .== 0)
+    @test result.eventID_fadc == UInt32.(1:10)
+
+    # thresholds should be finite and non-negative
+    @test all(isfinite.(result.threshold))
+    @test all(result.threshold .>= 0)
+    @test all(isfinite.(result.threshold_trap))
+    @test all(result.threshold_trap .>= 0)
+
+    # time values should be in µs and within waveform range
+    @test all(0.0u"µs" .<= result.t_max .<= 100.0u"µs")
+    @test all(0.0u"µs" .<= result.t_min .<= 100.0u"µs")
+end
+
+# Note: dsp_sipm_compressed is not tested here because it requires
+# bit-drop compressed waveform data (waveform_bit_drop) decoded via
+# LegendDataTypes.decode_data, which is hard to mock with synthetic data.
+# The DSP logic is identical to dsp_sipm.


### PR DESCRIPTION
Restructure SiPM DSP config from flat to nested layout (config.filters.sg / config.filters.trap) and add a full trapezoidal charge filter pipeline: PZ correction → TrapezoidalChargeFilter → IntersectMaximum trigger finding on the trap-filtered waveforms. First trigger cross is stored as trig_pos (old version) and new second low cross x_high stored as trig_pos_high and trig_pos_tot as the difference.

**Changes:**

- Nested config: SG and trap filter parameters are now under config.filters.sg and config.filters.trap

- New trap pipeline: InvCRFilter → TrapezoidalChargeFilter → IntersectMaximum trigger finding + discharge detection

- MAD-based thresholds: all threshold estimation now uses `thresholdstats_mad` (implemented in this PR in `src/thresholdstats.jl`)

- Clearer variable naming: wvfs → wvfs_sg, wvfs_int, wvfs_pz, wvfs_trap, etc.

- Fix e_max/e_min to use estats.max/estats.min

- New output columns: threshold_trap, trig_pos_trap, trig_pos_high_trap, trig_pos_tot_trap, trig_max_trap and DC equivalents

- `IntersectMaximum` extended to return `x_high` (downward threshold crossing) and `x_tot` (time-over-threshold) in `src/intersect_maximum.jl`

- Fix: `inters_DC_trap` now correctly uses `intflt_trap` instead of `intflt_sg`

- Updated docstrings for `dsp_sipm` and `dsp_sipm_compressed` with full column listings organized under SG and Trap filter sections

- Tests added for `thresholdstats_mad`, `IntersectMaximum` x_high/x_tot fields, and `dsp_sipm` integration

```mermaid
flowchart TD
    raw["Raw SiPM waveforms"]
    raw --> shift["shift_waveform (→ Float64)"]
    shift --> estats["extremestats → e_max, e_min, t_max, t_min"]
    shift --> trunc["TruncateFilter (HPGe window)"]
    trunc --> estats_trunc["extremestats → e_max_lar, e_min_lar"]
    shift --> sg["SavitzkyGolayFilter (derivative + smoothing)"]

    subgraph SG Pipeline
        sg --> |wvfs_sg| sg_trig["thresholdstats_mad + IntersectMaximum"]
        sg_trig --> |"trig_pos, trig_max"| sg_out(("SG triggers"))
        sg --> |wvfs_sg| integ["IntegratorFilter"]
        integ --> |wvfs_int| bl["signalstats → blmean, blsigma, …"]
        integ --> |wvfs_int| flip["× (−1) → wvfs_int_flip"]
        flip --> dc_sg["thresholdstats_mad + IntersectMaximum"]
        dc_sg --> |"trig_pos_DC, trig_max_DC"| dc_sg_out(("SG discharge triggers"))
    end

    subgraph Trap Pipeline
        integ --> |wvfs_int| pz["InvCRFilter (PZ correction)"]
        pz --> |wvfs_pz| trap["TrapezoidalChargeFilter"]
        trap --> |wvfs_trap| trap_trig["thresholdstats_mad + IntersectMaximum"]
        trap_trig --> |"trig_pos_trap, trig_pos_high_trap, trig_pos_tot_trap, trig_max_trap"| trap_out(("Trap triggers"))
        flip --> dc_trap["thresholdstats_mad + IntersectMaximum"]
        dc_trap --> |"trig_pos_DC_trap, trig_pos_high_DC_trap, trig_pos_tot_DC_trap, trig_max_DC_trap"| dc_trap_out(("Trap discharge triggers"))
    end
```

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Send tasks to Copilot coding agent from [Slack](https://gh.io/cca-slack-docs) and [Teams](https://gh.io/cca-teams-docs) to turn conversations into code. Copilot posts an update in your thread when it's finished.